### PR TITLE
Add Alentora RSO Properties plugin

### DIFF
--- a/alentora-rso-properties/admin/settings-page.php
+++ b/alentora-rso-properties/admin/settings-page.php
@@ -1,0 +1,15 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Alentora RSO Settings', 'alentora-rso' ); ?></h1>
+    <form method="post" action="options.php">
+        <?php
+        settings_fields( 'alentora_rso_options' );
+        do_settings_sections( 'alentora-rso-settings' );
+        submit_button();
+        ?>
+    </form>
+</div>

--- a/alentora-rso-properties/alentora_rso_properties.php
+++ b/alentora-rso-properties/alentora_rso_properties.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Plugin Name: Alentora RSO Properties
+ * Description: Integrates with Resales Online API to display property listings and search forms.
+ * Version: 1.0.0
+ * Author: Your Name
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+class Alentora_RSO_Properties {
+
+    const VERSION = '1.0.0';
+
+    public function __construct() {
+        $this->define_constants();
+        $this->includes();
+        $this->init_hooks();
+    }
+
+    private function define_constants() {
+        define( 'ALENTORA_RSO_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+        define( 'ALENTORA_RSO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+    }
+
+    private function includes() {
+        require_once ALENTORA_RSO_PLUGIN_PATH . 'includes/class-alentora-rso-api.php';
+        require_once ALENTORA_RSO_PLUGIN_PATH . 'includes/class-alentora-shortcodes.php';
+    }
+
+    private function init_hooks() {
+        register_activation_hook( __FILE__, array( $this, 'activate' ) );
+        add_action( 'admin_menu', array( $this, 'register_settings_page' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+    }
+
+    public function activate() {
+        add_option( 'alentora_rso_api_key', '' );
+        add_option( 'alentora_rso_client_id', '' );
+        add_option( 'alentora_rso_default_filter_id', '' );
+    }
+
+    public function register_settings_page() {
+        add_options_page(
+            __( 'Alentora RSO Settings', 'alentora-rso' ),
+            __( 'Alentora RSO', 'alentora-rso' ),
+            'manage_options',
+            'alentora-rso-settings',
+            array( $this, 'render_settings_page' )
+        );
+    }
+
+    public function register_settings() {
+        register_setting( 'alentora_rso_options', 'alentora_rso_api_key', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+        register_setting( 'alentora_rso_options', 'alentora_rso_client_id', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+        register_setting( 'alentora_rso_options', 'alentora_rso_default_filter_id', array( 'sanitize_callback' => 'absint' ) );
+
+        add_settings_section(
+            'alentora_rso_main_section',
+            __( 'API Settings', 'alentora-rso' ),
+            '__return_false',
+            'alentora-rso-settings'
+        );
+
+        add_settings_field(
+            'alentora_rso_api_key',
+            __( 'API Key', 'alentora-rso' ),
+            array( $this, 'render_api_key_field' ),
+            'alentora-rso-settings',
+            'alentora_rso_main_section'
+        );
+
+        add_settings_field(
+            'alentora_rso_client_id',
+            __( 'Client ID', 'alentora-rso' ),
+            array( $this, 'render_client_id_field' ),
+            'alentora-rso-settings',
+            'alentora_rso_main_section'
+        );
+
+        add_settings_field(
+            'alentora_rso_default_filter_id',
+            __( 'Default Filter ID', 'alentora-rso' ),
+            array( $this, 'render_filter_id_field' ),
+            'alentora-rso-settings',
+            'alentora_rso_main_section'
+        );
+    }
+
+    public function enqueue_assets() {
+        wp_enqueue_style( 'alentora-rso-style', ALENTORA_RSO_PLUGIN_URL . 'assets/css/style.css', array(), self::VERSION );
+    }
+
+    public function render_api_key_field() {
+        $value = get_option( 'alentora_rso_api_key', '' );
+        echo '<input type="text" name="alentora_rso_api_key" value="' . esc_attr( $value ) . '" class="regular-text" />';
+    }
+
+    public function render_client_id_field() {
+        $value = get_option( 'alentora_rso_client_id', '' );
+        echo '<input type="text" name="alentora_rso_client_id" value="' . esc_attr( $value ) . '" class="regular-text" />';
+    }
+
+    public function render_filter_id_field() {
+        $value = get_option( 'alentora_rso_default_filter_id', '' );
+        echo '<input type="number" name="alentora_rso_default_filter_id" value="' . esc_attr( $value ) . '" class="small-text" />';
+    }
+
+    public function render_settings_page() {
+        if ( ! current_user_can( "manage_options" ) ) {
+            return;
+        }
+        include ALENTORA_RSO_PLUGIN_PATH . "admin/settings-page.php";
+    }
+}
+
+// Initialize plugin
+add_action( 'plugins_loaded', function() {
+    new Alentora_RSO_Properties();
+} );
+
+?>

--- a/alentora-rso-properties/assets/css/style.css
+++ b/alentora-rso-properties/assets/css/style.css
@@ -1,0 +1,16 @@
+/*
+ * Basic styles for Alentora RSO Properties
+ */
+
+.alentora-rso-search-form {
+    /* Add your form styling here */
+}
+
+.alentora-rso-properties {
+    /* Container for property listings */
+}
+
+.alentora-rso-property {
+    /* Individual property item */
+    margin-bottom: 20px;
+}

--- a/alentora-rso-properties/includes/class-alentora-rso-api.php
+++ b/alentora-rso-properties/includes/class-alentora-rso-api.php
@@ -1,0 +1,66 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Alentora_RSO_API {
+
+    protected $api_key;
+    protected $client_id;
+
+    public function __construct() {
+        $this->api_key   = get_option( 'alentora_rso_api_key', '' );
+        $this->client_id = get_option( 'alentora_rso_client_id', '' );
+    }
+
+    private function request( $endpoint, $args = array() ) {
+        $url = add_query_arg( $args, $endpoint );
+
+        $response = wp_remote_get( $url, array(
+            'headers' => array(
+                'API-KEY'   => $this->api_key,
+                'CLIENT-ID' => $this->client_id,
+            ),
+            'timeout' => 15,
+        ) );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( 200 !== $code ) {
+            return new WP_Error( 'api_error', __( 'Unexpected API response.', 'alentora-rso' ) );
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+
+        if ( json_last_error() !== JSON_ERROR_NONE ) {
+            return new WP_Error( 'json_error', __( 'Error decoding API response.', 'alentora-rso' ) );
+        }
+
+        return $data;
+    }
+
+    public function get_properties( array $args = array() ) {
+        $endpoint = 'https://api.resales-online.com/v6/properties';
+        return $this->request( $endpoint, $args );
+    }
+
+    public function get_search_results( array $args = array() ) {
+        $endpoint = 'https://api.resales-online.com/v6/search';
+        return $this->request( $endpoint, $args );
+    }
+
+    public function get_properties_by_refs( array $refs = array() ) {
+        $endpoint = 'https://api.resales-online.com/v6/properties-by-ref';
+        $args = array( 'refs' => implode( ',', $refs ) );
+        return $this->request( $endpoint, $args );
+    }
+
+    public function get_property_details( $id ) {
+        $endpoint = 'https://api.resales-online.com/v6/property/' . urlencode( $id );
+        return $this->request( $endpoint );
+    }
+}

--- a/alentora-rso-properties/includes/class-alentora-shortcodes.php
+++ b/alentora-rso-properties/includes/class-alentora-shortcodes.php
@@ -1,0 +1,138 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Alentora_Shortcodes {
+
+    protected $api;
+
+    public function __construct() {
+        $this->api = new Alentora_RSO_API();
+        add_shortcode( 'alentora_rso_search', array( $this, 'search_form_shortcode' ) );
+        add_shortcode( 'alentora_rso_properties', array( $this, 'properties_shortcode' ) );
+        add_shortcode( 'alentora_rso_properties_by_refs', array( $this, 'properties_by_refs_shortcode' ) );
+    }
+
+    /**
+     * Render search form shortcode
+     */
+    public function search_form_shortcode( $atts ) {
+        $defaults = array(
+            'is_form_rental' => 'short',
+            'filter_id' => get_option( 'alentora_rso_default_filter_id', '' ),
+            'results_own_page' => 'false',
+            'include_title_page' => '',
+            'number_properties' => '',
+            'all_areas' => 'false',
+            'no_show_areas' => 'false',
+            'no_show_type' => 'false',
+            'no_show_rooms' => 'false',
+            'no_show_baths' => 'false',
+            'no_show_from_price' => 'false',
+            'no_show_to_price' => 'false',
+            'no_show_reference_search' => 'false',
+            'no_show_number_properties' => 'false',
+            'no_show_new_development' => 'false',
+            'show_advanced_search' => 'false',
+            'p_musthavefeatures' => '0',
+        );
+        $atts = shortcode_atts( $defaults, $atts, 'alentora_rso_search' );
+
+        ob_start();
+        ?>
+        <form class="alentora-rso-search-form">
+            <?php wp_nonce_field( 'alentora_rso_search', 'alentora_rso_nonce' ); ?>
+            <label>
+                <?php esc_html_e( 'Keyword', 'alentora-rso' ); ?>
+                <input type="text" name="keyword" />
+            </label>
+            <button type="submit"><?php esc_html_e( 'Search', 'alentora-rso' ); ?></button>
+        </form>
+        <?php
+        return ob_get_clean();
+    }
+
+    /**
+     * Render properties list shortcode
+     */
+    public function properties_shortcode( $atts ) {
+        $defaults = array(
+            'filter_id' => get_option( 'alentora_rso_default_filter_id', '' ),
+            'include_search' => 'false',
+            'is_form_rental_search' => 'short',
+            'results_own_page_search' => 'false',
+            'include_pagination' => 'true',
+            'include_sort' => 'true',
+            'include_num_results' => 'true',
+            'include_view_type' => 'true',
+            'view_type' => 'card',
+            'location' => '',
+            'type' => '',
+            'features' => '',
+            'p_sortyype' => '0',
+            'p_pagesize' => '10',
+            'p_new_devs' => 'exclude',
+        );
+        $atts = shortcode_atts( $defaults, $atts, 'alentora_rso_properties' );
+
+        $args = array(
+            'filter_id' => absint( $atts['filter_id'] ),
+            'location'  => sanitize_text_field( $atts['location'] ),
+            'type'      => sanitize_text_field( $atts['type'] ),
+            'features'  => sanitize_text_field( $atts['features'] ),
+        );
+
+        $properties = $this->api->get_properties( $args );
+        if ( is_wp_error( $properties ) ) {
+            return '<p>' . esc_html( $properties->get_error_message() ) . '</p>';
+        }
+
+        ob_start();
+        echo '<div class="alentora-rso-properties">';
+        if ( ! empty( $properties ) ) {
+            foreach ( $properties as $property ) {
+                echo '<div class="alentora-rso-property">';
+                echo '<h3>' . esc_html( $property['title'] ?? '' ) . '</h3>';
+                echo '</div>';
+            }
+        } else {
+            esc_html_e( 'No properties found.', 'alentora-rso' );
+        }
+        echo '</div>';
+        return ob_get_clean();
+    }
+
+    /**
+     * Render properties by references shortcode
+     */
+    public function properties_by_refs_shortcode( $atts ) {
+        $defaults = array(
+            'filter_id' => get_option( 'alentora_rso_default_filter_id', '' ),
+            'references' => '',
+        );
+        $atts = shortcode_atts( $defaults, $atts, 'alentora_rso_properties_by_refs' );
+
+        $refs = array_filter( array_map( 'trim', explode( ',', $atts['references'] ) ) );
+        $properties = $this->api->get_properties_by_refs( $refs );
+        if ( is_wp_error( $properties ) ) {
+            return '<p>' . esc_html( $properties->get_error_message() ) . '</p>';
+        }
+
+        ob_start();
+        echo '<div class="alentora-rso-properties">';
+        if ( ! empty( $properties ) ) {
+            foreach ( $properties as $property ) {
+                echo '<div class="alentora-rso-property">';
+                echo '<h3>' . esc_html( $property['title'] ?? '' ) . '</h3>';
+                echo '</div>';
+            }
+        } else {
+            esc_html_e( 'No properties found.', 'alentora-rso' );
+        }
+        echo '</div>';
+        return ob_get_clean();
+    }
+}
+
+new Alentora_Shortcodes();


### PR DESCRIPTION
## Summary
- add the Alentora RSO Properties plugin scaffold
- include API helper class and shortcode handlers
- add admin settings page for API credentials
- include base stylesheet for the plugin

## Testing
- `php -l alentora-rso-properties/alentora_rso_properties.php` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684452d6676083339e88550ce7177dc7